### PR TITLE
Stackable Item duplication fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'net.minecraftforge.gradle.forge'
 //Only edit below this line, the above code adds and enables the necessary things for Forge to be setup.
 
 
-version = "1.12.2_v4"
+version = "1.12.2_v5"
 group = "com.cookiehook.liquidenchanting" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "liquidenchanting"
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ compileJava {
 }
 
 minecraft {
-    version = "1.12.2-14.23.5.2768"
+    version = "1.12.2-14.23.5.2847"
     runDir = "../run"
     
     // the mappings can be changed at any time, and must be in the following format.

--- a/src/main/java/com/cookiehook/liquidenchanting/crafting/PotionRecipeFactory.java
+++ b/src/main/java/com/cookiehook/liquidenchanting/crafting/PotionRecipeFactory.java
@@ -116,6 +116,12 @@ public class PotionRecipeFactory implements IRecipeFactory {
                 return false;
             }
 
+            // Check against maxStackSize makes sure we don't enchant stackable weapons (like throwables), as I can't
+            // get them to apply their effect on impact. Also check that we only have 1 item in case of glitched 0-item stacks.
+            if (centreItem.getMaxStackSize() != 1 || centreItem.getCount() != 1) {
+                return false;
+            }
+
             // This is predominantly a copy / paste from the vanilla implementation.
             // Difference being skip the centre item, and check the NBT tags all match each other.
             for (int x = 0; x < inventory.getWidth(); x++) {

--- a/src/main/java/com/cookiehook/liquidenchanting/util/Reference.java
+++ b/src/main/java/com/cookiehook/liquidenchanting/util/Reference.java
@@ -4,7 +4,7 @@ public class Reference {
 
     public static final String MOD_ID = "liquidenchanting";
     public static final String MOD_NAME = "Liquid Enchanting";
-    public static final String VERSION = "1.12.2_v4";
+    public static final String VERSION = "1.12.2_v5";
     public static final String CLIENT_PROXY_CLASS = "com.cookiehook.liquidenchanting.proxy.ClientProxy";
     public static final String COMMON_PROXY_CLASS = "com.cookiehook.liquidenchanting.proxy.CommonProxy";
 


### PR DESCRIPTION
Fixed issue where copying the itemstack would output up to a full stack of items, but only consume one item when crafting.

Fixed by limiting crafting to non-stackable items, as stackable & enchantable items are likely to be throwable projectiles or ammuntion, which don't work anyway.